### PR TITLE
Integrate Oracle Feed in `oracle_integration.cairo`

### DIFF
--- a/docs/oracle_integration.md
+++ b/docs/oracle_integration.md
@@ -1,0 +1,81 @@
+# Oracle Integration Documentation
+
+## Overview
+
+The Oracle Integration system provides secure, reliable data feeds for the Starknet insurance protocol. It enables trusted oracles to submit real-world data that can trigger insurance claims automatically.
+
+## Core Features
+
+### Data Submission
+
+- **Secure Oracle Whitelisting**: Only trusted oracles can submit data
+- **Timestamp Validation**: Prevents future timestamps and stale data
+- **Replay Protection**: Nonce-based system prevents duplicate submissions
+- **Data Freshness**: Configurable validity window ensures recent data
+
+### Claim Processing
+
+- **Automated Validation**: Real-time data verification for claims
+- **Trigger Protection**: Prevents duplicate claim triggering
+- **Event Logging**: Comprehensive audit trail for all operations
+
+## Contract Interface
+
+### Core Functions
+
+#### `submit_data(oracle_id, payload, timestamp)`
+
+Submits data from a trusted oracle with security validations.
+
+**Parameters:**
+
+- `oracle_id`: Address of the submitting oracle
+- `payload`: Data payload (felt252 format)
+- `timestamp`: Unix timestamp of the data
+
+**Security Checks:**
+
+- Oracle must be in trusted list
+- Timestamp cannot be in the future
+- Data must be within validity window
+- Prevents replay attacks
+
+#### `validate_data(oracle_id, claim_id) -> bool`
+
+Validates if oracle data is suitable for claim processing.
+
+**Returns:** Boolean indicating data validity
+
+#### `trigger_claim(claim_id)`
+
+Triggers an insurance claim based on oracle data.
+
+**Authorization:** Only trusted oracles or contract owner
+
+### Management Functions
+
+#### `add_trusted_oracle(oracle_address)`
+
+Adds an oracle to the trusted list (owner only).
+
+#### `remove_trusted_oracle(oracle_address)`
+
+Removes an oracle from the trusted list (owner only).
+
+#### `set_data_validity_window(window_seconds)`
+
+Sets the data freshness window (owner only).
+
+## Events
+
+### `OracleUpdated`
+
+Emitted when oracle submits new data.
+
+```cairo
+struct OracleUpdated {
+    oracle_id: ContractAddress,
+    payload: felt252,
+    timestamp: u64,
+}
+```

--- a/src/oracle_integration.cairo
+++ b/src/oracle_integration.cairo
@@ -1,0 +1,173 @@
+use starknet::{ContractAddress, get_caller_address, get_block_timestamp};
+
+#[starknet::interface]
+trait IOracleIntegration<TContractState> {
+    fn submit_data(ref self: TContractState, oracle_id: ContractAddress, payload: felt252, timestamp: u64);
+    fn validate_data(self: @TContractState, oracle_id: ContractAddress, claim_id: felt252) -> bool;
+    fn trigger_claim(ref self: TContractState, claim_id: felt252);
+    fn add_trusted_oracle(ref self: TContractState, oracle_address: ContractAddress);
+    fn remove_trusted_oracle(ref self: TContractState, oracle_address: ContractAddress);
+    fn is_trusted_oracle(self: @TContractState, oracle_address: ContractAddress) -> bool;
+    fn get_oracle_data(self: @TContractState, oracle_id: ContractAddress) -> (felt252, u64);
+    fn set_data_validity_window(ref self: TContractState, window_seconds: u64);
+}
+
+#[starknet::contract]
+mod OracleIntegration {
+    use super::IOracleIntegration;
+    use starknet::{ContractAddress, get_caller_address, get_block_timestamp};
+    use starknet::storage::{
+        StoragePointerReadAccess, StoragePointerWriteAccess, StoragePathEntry, Map
+    };
+
+    #[storage]
+    struct Storage {
+        owner: ContractAddress,
+        trusted_oracles: Map<ContractAddress, bool>,
+        oracle_data: Map<ContractAddress, (felt252, u64)>, // (payload, timestamp)
+        oracle_nonces: Map<ContractAddress, u64>, // For replay protection
+        data_validity_window: u64, // Seconds
+        claim_triggers: Map<felt252, bool>, // Track triggered claims
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        OracleUpdated: OracleUpdated,
+        ClaimTriggered: ClaimTriggered,
+        TrustedOracleAdded: TrustedOracleAdded,
+        TrustedOracleRemoved: TrustedOracleRemoved,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct OracleUpdated {
+        oracle_id: ContractAddress,
+        payload: felt252,
+        timestamp: u64,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct ClaimTriggered {
+        claim_id: felt252,
+        triggered_by_oracle_id: ContractAddress,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct TrustedOracleAdded {
+        oracle_address: ContractAddress,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    struct TrustedOracleRemoved {
+        oracle_address: ContractAddress,
+    }
+
+    #[constructor]
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.owner.write(owner);
+        self.data_validity_window.write(3600); // Default: 1 hour
+    }
+
+    #[abi(embed_v0)]
+    impl OracleIntegrationImpl of IOracleIntegration<ContractState> {
+        fn submit_data(ref self: ContractState, oracle_id: ContractAddress, payload: felt252, timestamp: u64) {
+            // Security checks
+            assert(self.is_trusted_oracle(oracle_id), 'Oracle not trusted');
+            
+            let current_time = get_block_timestamp();
+            assert(timestamp <= current_time, 'Future timestamp not allowed');
+            
+            // Check data freshness
+            let validity_window = self.data_validity_window.read();
+            assert(current_time - timestamp <= validity_window, 'Data too old');
+            
+            // Replay protection
+            let last_nonce = self.oracle_nonces.entry(oracle_id).read();
+            assert(timestamp > last_nonce, 'Replay attack detected');
+            
+            // Store data and update nonce
+            self.oracle_data.entry(oracle_id).write((payload, timestamp));
+            self.oracle_nonces.entry(oracle_id).write(timestamp);
+            
+            // Emit event
+            self.emit(OracleUpdated { oracle_id, payload, timestamp });
+        }
+
+        fn validate_data(self: @ContractState, oracle_id: ContractAddress, claim_id: felt252) -> bool {
+            // Check if oracle is trusted
+            if !self.is_trusted_oracle(oracle_id) {
+                return false;
+            }
+            
+            // Get oracle data
+            let (payload, timestamp) = self.oracle_data.entry(oracle_id).read();
+            
+            // Check if data exists
+            if timestamp == 0 {
+                return false;
+            }
+            
+            // Check data freshness
+            let current_time = get_block_timestamp();
+            let validity_window = self.data_validity_window.read();
+            if current_time - timestamp > validity_window {
+                return false;
+            }
+            
+            // Additional validation logic can be added here
+            // For now, we assume any fresh data from trusted oracle is valid
+            true
+        }
+
+        fn trigger_claim(ref self: ContractState, claim_id: felt252) {
+            let caller = get_caller_address();
+            
+            // Check if caller is trusted oracle or owner
+            let is_authorized = self.is_trusted_oracle(caller) || caller == self.owner.read();
+            assert(is_authorized, 'Unauthorized caller');
+            
+            // Prevent double triggering
+            assert(!self.claim_triggers.entry(claim_id).read(), 'Claim already triggered');
+            
+            // Mark claim as triggered
+            self.claim_triggers.entry(claim_id).write(true);
+            
+            // Emit event
+            self.emit(ClaimTriggered { claim_id, triggered_by_oracle_id: caller });
+        }
+
+        fn add_trusted_oracle(ref self: ContractState, oracle_address: ContractAddress) {
+            self._only_owner();
+            self.trusted_oracles.entry(oracle_address).write(true);
+            self.emit(TrustedOracleAdded { oracle_address });
+        }
+
+        fn remove_trusted_oracle(ref self: ContractState, oracle_address: ContractAddress) {
+            self._only_owner();
+            self.trusted_oracles.entry(oracle_address).write(false);
+            self.emit(TrustedOracleRemoved { oracle_address });
+        }
+
+        fn is_trusted_oracle(self: @ContractState, oracle_address: ContractAddress) -> bool {
+            self.trusted_oracles.entry(oracle_address).read()
+        }
+
+        fn get_oracle_data(self: @ContractState, oracle_id: ContractAddress) -> (felt252, u64) {
+            self.oracle_data.entry(oracle_id).read()
+        }
+
+        fn set_data_validity_window(ref self: ContractState, window_seconds: u64) {
+            self._only_owner();
+            assert(window_seconds > 0, 'Invalid validity window');
+            self.data_validity_window.write(window_seconds);
+        }
+    }
+
+    #[generate_trait]
+    impl InternalImpl of InternalTrait {
+        fn _only_owner(self: @ContractState) {
+            let caller = get_caller_address();
+            assert(caller == self.owner.read(), 'Only owner allowed');
+        }
+    }
+}

--- a/tests/test_oracle_update.cairo
+++ b/tests/test_oracle_update.cairo
@@ -1,0 +1,219 @@
+use starknet::{ContractAddress, contract_address_const, get_block_timestamp};
+use snforge_std::{declare, ContractClassTrait, DeclareResultTrait, start_cheat_block_timestamp, stop_cheat_block_timestamp, spy_events, EventSpyAssertionsTrait};
+
+use oracle_integration::oracle_integration::{IOracleIntegrationDispatcher, IOracleIntegrationDispatcherTrait};
+
+fn OWNER() -> ContractAddress {
+    contract_address_const::<'owner'>()
+}
+
+fn ORACLE_1() -> ContractAddress {
+    contract_address_const::<'oracle1'>()
+}
+
+fn ORACLE_2() -> ContractAddress {
+    contract_address_const::<'oracle2'>()
+}
+
+fn deploy_contract() -> IOracleIntegrationDispatcher {
+    let contract = declare("OracleIntegration").unwrap().contract_class();
+    let (contract_address, _) = contract.deploy(@array![OWNER().into()]).unwrap();
+    IOracleIntegrationDispatcher { contract_address }
+}
+
+#[test]
+fn test_submit_valid_data() {
+    let contract = deploy_contract();
+    
+    // Add trusted oracle
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.add_trusted_oracle(ORACLE_1());
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Submit data
+    let timestamp = get_block_timestamp() - 300; // 5 minutes ago
+    let payload = 'HURRICANE_CATEGORY_2';
+    
+    start_cheat_caller_address(contract.contract_address, ORACLE_1());
+    contract.submit_data(ORACLE_1(), payload, timestamp);
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Verify data was stored
+    let (stored_payload, stored_timestamp) = contract.get_oracle_data(ORACLE_1());
+    assert(stored_payload == payload, 'Payload mismatch');
+    assert(stored_timestamp == timestamp, 'Timestamp mismatch');
+}
+
+#[test]
+#[should_panic(expected: ('Oracle not trusted',))]
+fn test_submit_data_untrusted_oracle() {
+    let contract = deploy_contract();
+    
+    let timestamp = get_block_timestamp() - 300;
+    let payload = 'TEST_DATA';
+    
+    // Try to submit data from untrusted oracle
+    start_cheat_caller_address(contract.contract_address, ORACLE_1());
+    contract.submit_data(ORACLE_1(), payload, timestamp);
+}
+
+#[test]
+#[should_panic(expected: ('Future timestamp not allowed',))]
+fn test_submit_future_timestamp() {
+    let contract = deploy_contract();
+    
+    // Add trusted oracle
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.add_trusted_oracle(ORACLE_1());
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Try to submit data with future timestamp
+    let future_timestamp = get_block_timestamp() + 3600; // 1 hour in future
+    let payload = 'TEST_DATA';
+    
+    start_cheat_caller_address(contract.contract_address, ORACLE_1());
+    contract.submit_data(ORACLE_1(), payload, future_timestamp);
+}
+
+#[test]
+#[should_panic(expected: ('Data too old',))]
+fn test_submit_stale_data() {
+    let contract = deploy_contract();
+    
+    // Add trusted oracle
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.add_trusted_oracle(ORACLE_1());
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Try to submit very old data (2 hours ago, beyond default 1 hour window)
+    let old_timestamp = get_block_timestamp() - 7200;
+    let payload = 'OLD_DATA';
+    
+    start_cheat_caller_address(contract.contract_address, ORACLE_1());
+    contract.submit_data(ORACLE_1(), payload, old_timestamp);
+}
+
+#[test]
+#[should_panic(expected: ('Replay attack detected',))]
+fn test_replay_protection() {
+    let contract = deploy_contract();
+    
+    // Add trusted oracle
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.add_trusted_oracle(ORACLE_1());
+    stop_cheat_caller_address(contract.contract_address);
+    
+    let timestamp = get_block_timestamp() - 300;
+    let payload = 'TEST_DATA';
+    
+    start_cheat_caller_address(contract.contract_address, ORACLE_1());
+    
+    // Submit data first time (should succeed)
+    contract.submit_data(ORACLE_1(), payload, timestamp);
+    
+    // Try to submit same timestamp again (should fail)
+    contract.submit_data(ORACLE_1(), payload, timestamp);
+}
+
+#[test]
+fn test_validate_data_success() {
+    let contract = deploy_contract();
+    
+    // Add trusted oracle
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.add_trusted_oracle(ORACLE_1());
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Submit fresh data
+    let timestamp = get_block_timestamp() - 300;
+    let payload = 'VALID_DATA';
+    
+    start_cheat_caller_address(contract.contract_address, ORACLE_1());
+    contract.submit_data(ORACLE_1(), payload, timestamp);
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Validate data
+    let claim_id = 'test_claim_123';
+    let is_valid = contract.validate_data(ORACLE_1(), claim_id);
+    assert(is_valid, 'Data should be valid');
+}
+
+#[test]
+fn test_validate_data_untrusted_oracle() {
+    let contract = deploy_contract();
+    
+    let claim_id = 'test_claim_123';
+    let is_valid = contract.validate_data(ORACLE_1(), claim_id);
+    assert(!is_valid, 'Untrusted oracle should be invalid');
+}
+
+#[test]
+fn test_trigger_claim_success() {
+    let contract = deploy_contract();
+    
+    // Add trusted oracle
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.add_trusted_oracle(ORACLE_1());
+    stop_cheat_caller_address(contract.contract_address);
+    
+    let claim_id = 'test_claim_456';
+    
+    // Trigger claim as trusted oracle
+    start_cheat_caller_address(contract.contract_address, ORACLE_1());
+    contract.trigger_claim(claim_id);
+    stop_cheat_caller_address(contract.contract_address);
+}
+
+#[test]
+#[should_panic(expected: ('Claim already triggered',))]
+fn test_prevent_double_trigger() {
+    let contract = deploy_contract();
+    
+    // Add trusted oracle
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.add_trusted_oracle(ORACLE_1());
+    stop_cheat_caller_address(contract.contract_address);
+    
+    let claim_id = 'test_claim_789';
+    
+    start_cheat_caller_address(contract.contract_address, ORACLE_1());
+    
+    // Trigger claim first time (should succeed)
+    contract.trigger_claim(claim_id);
+    
+    // Try to trigger same claim again (should fail)
+    contract.trigger_claim(claim_id);
+}
+
+#[test]
+fn test_event_emissions() {
+    let contract = deploy_contract();
+    let mut spy = spy_events();
+    
+    // Add trusted oracle
+    start_cheat_caller_address(contract.contract_address, OWNER());
+    contract.add_trusted_oracle(ORACLE_1());
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Submit data and check event
+    let timestamp = get_block_timestamp() - 300;
+    let payload = 'EVENT_TEST_DATA';
+    
+    start_cheat_caller_address(contract.contract_address, ORACLE_1());
+    contract.submit_data(ORACLE_1(), payload, timestamp);
+    stop_cheat_caller_address(contract.contract_address);
+    
+    // Check OracleUpdated event was emitted
+    spy.assert_emitted(@array![
+        (contract.contract_address, oracle_integration::oracle_integration::Event::OracleUpdated(
+            oracle_integration::oracle_integration::OracleUpdated {
+                oracle_id: ORACLE_1(),
+                payload: payload,
+                timestamp: timestamp
+            }
+        ))
+    ]);
+}
+
+// Helper functions for testing
+use snforge_std::{start_cheat_caller_address, stop_cheat_caller_address};


### PR DESCRIPTION
closes #4 

This pull request introduces the integration of an **Oracle Feed** into the `oracle_integration.cairo` contract. The goal is to enable the contract to fetch, read, and utilize off-chain data securely within the StarkNet ecosystem.

### Changes Introduced

* Added Oracle Feed interface to interact with the external oracle.
* Implemented functions to request and fetch oracle data.
* Integrated storage structures for persisting oracle responses.
* Added validation and error handling for oracle results.
* Updated comments and inline documentation for better readability.

### Acceptance Criteria

* [ ] Contract should successfully connect to the Oracle Feed.
* [ ] Functions should allow reading the latest oracle data.
* [ ] Data integrity and validation must be ensured.
* [ ] Tests should cover edge cases such as missing or invalid oracle data.

### Checklist

* [ ] Unit tests added/updated.
* [ ] Documentation updated.
* [ ] Contract compiles successfully with no warnings.
* [ ] Oracle interaction verified on testnet (if applicable).
